### PR TITLE
fix: Keep chamber lights on through priming in PRINT_START

### DIFF
--- a/klipper/macros/print_start.cfg
+++ b/klipper/macros/print_start.cfg
@@ -28,9 +28,10 @@ gcode:
       M112 # EStop!
     {% endif %}
 
-    # Turn on the lights, but set a timeout to turn them off in case startup fails
+    # Turn the lights on with a short timeout so they don't stay on forever if
+    # homing fails before we get a chance to start the print.
     LIGHTS
-    LIGHTS_OFF_AFTER SECONDS=120
+    LIGHTS_OFF_AFTER SECONDS=300
 
     # Start pre-heating the bed while we perform initial homing
     M140 S{bed_temp}
@@ -46,6 +47,14 @@ gcode:
 
     # Set absolute positioning for XYZ
     G90
+
+    # Pre-clean and bed/chamber heat-up are open-ended waits (chamber heating can
+    # take up to an hour). Keep the lights on with NO timeout across them:
+    # PRINT_START holds the g-code mutex throughout, so a lights_off that fired
+    # here couldn't run until startup finishes anyway, and any finite value would
+    # just risk turning the lights off the instant the print begins. The bounded
+    # steps on either side keep their own timeouts.
+    LIGHTS
 
     ########################
     # Pre-Clean The Nozzle #
@@ -67,8 +76,7 @@ gcode:
     #  Wait for Heating   #
     #######################
     {% if printer['heater_bed'].temperature < bed_temp %}
-      # Keep the lights on while heating the bed
-      LIGHTS_OFF_AFTER SECONDS=600
+      # No lights timeout while heating (see the heating-waits note above).
       M104 S0
       PARK_NOZZLE
       _NOTIFY T="Heating Bed"
@@ -80,27 +88,19 @@ gcode:
     #####################
     # Now wait for the chamber to reach the desired operating temperature
     {% if printer['temperature_sensor chamber'].temperature < chamber_temp %}
-      # Keep the lights on while heating the chamber. This is the longest part
-      # of startup (it can take up to an hour), so the safety timeout has to
-      # outlast it: a shorter value fires mid-PRINT_START and the deferred
-      # lights_off turns the chamber off the moment startup finishes (see the
-      # final-calibration timeout below for the full explanation).
-      LIGHTS_OFF_AFTER SECONDS=7200
+      # No lights timeout while heating (see the heating-waits note above).
       M104 S0
       PARK_NOZZLE
       _NOTIFY T="Heating Chamber"
       M191 S{chamber_temp}
     {% endif %}
 
-    # Keep the lights on during the final calibration and priming. This is the
-    # longest part of startup (gantry leveling, Z-offset, bed meshing, nozzle
-    # heat-up and priming), so its safety timeout must comfortably outlast it.
-    # If it fires before PRINT_START finishes, the lights_off delayed_gcode runs
-    # under the g-code command mutex that PRINT_START holds for its whole run, so
-    # it's deferred until PRINT_START completes - landing *after* the closing
-    # LIGHTS call turns the chamber on, leaving it dark for the entire print.
-    # The DURATION=0 cancel inside LIGHTS can't help once the timer has fired.
-    LIGHTS_OFF_AFTER SECONDS=1800
+    # Past the heating waits, the remaining work (gantry leveling, Z-offset,
+    # meshing, priming) is bounded and aborts cleanly on failure, so re-arm a
+    # reasonable timeout: if one of these steps errors out before PRINT_START
+    # reaches the closing LIGHTS, this turns the lights off rather than leaving
+    # them on indefinitely. It only needs to outlast the work it covers.
+    LIGHTS_OFF_AFTER SECONDS=900
 
     # Pass through the material information to the MPC controller
     _SET_MPC_MATERIAL MATERIAL={params.MATERIAL}

--- a/klipper/macros/print_start.cfg
+++ b/klipper/macros/print_start.cfg
@@ -88,8 +88,15 @@ gcode:
       M191 S{chamber_temp}
     {% endif %}
 
-    # Keep the lights on for an appropriate amount during the final calibration
-    LIGHTS_OFF_AFTER SECONDS=300
+    # Keep the lights on during the final calibration and priming. This is the
+    # longest part of startup (gantry leveling, Z-offset, bed meshing, nozzle
+    # heat-up and priming), so its safety timeout must comfortably outlast it.
+    # If it fires before PRINT_START finishes, the lights_off delayed_gcode runs
+    # under the g-code command mutex that PRINT_START holds for its whole run, so
+    # it's deferred until PRINT_START completes - landing *after* the closing
+    # LIGHTS call turns the chamber on, leaving it dark for the entire print.
+    # The DURATION=0 cancel inside LIGHTS can't help once the timer has fired.
+    LIGHTS_OFF_AFTER SECONDS=1800
 
     # Pass through the material information to the MPC controller
     _SET_MPC_MATERIAL MATERIAL={params.MATERIAL}

--- a/klipper/macros/print_start.cfg
+++ b/klipper/macros/print_start.cfg
@@ -80,8 +80,12 @@ gcode:
     #####################
     # Now wait for the chamber to reach the desired operating temperature
     {% if printer['temperature_sensor chamber'].temperature < chamber_temp %}
-      # Keep the lights on while heating the chamber (for up to 30m)
-      LIGHTS_OFF_AFTER SECONDS=1800
+      # Keep the lights on while heating the chamber. This is the longest part
+      # of startup (it can take up to an hour), so the safety timeout has to
+      # outlast it: a shorter value fires mid-PRINT_START and the deferred
+      # lights_off turns the chamber off the moment startup finishes (see the
+      # final-calibration timeout below for the full explanation).
+      LIGHTS_OFF_AFTER SECONDS=7200
       M104 S0
       PARK_NOZZLE
       _NOTIFY T="Heating Chamber"

--- a/klipper/macros/print_start.cfg
+++ b/klipper/macros/print_start.cfg
@@ -69,10 +69,12 @@ gcode:
     {% endif %}
 
     # Bed and chamber heat-up are open-ended waits (chamber heating can take up to
-    # an hour). Keep the lights on with NO timeout across them: PRINT_START holds
-    # the g-code mutex throughout, so a lights_off that fired here couldn't run
-    # until startup finishes anyway, and any finite value would just risk turning
-    # the lights off the instant the print begins.
+    # an hour), so they run with NO timeout. This LIGHTS is load-bearing: besides
+    # keeping the lights on it CANCELS the still-pending pre-clean/homing timeout
+    # (it ends in UPDATE_DELAYED_GCODE ID=lights_off DURATION=0). Without it the
+    # previous timer would keep counting down into the heating waits. (It couldn't
+    # actually fire while PRINT_START holds the g-code mutex, but we clear it so
+    # nothing is left armed - don't drop this call when editing.)
     LIGHTS
 
     #######################

--- a/klipper/macros/print_start.cfg
+++ b/klipper/macros/print_start.cfg
@@ -48,18 +48,14 @@ gcode:
     # Set absolute positioning for XYZ
     G90
 
-    # Pre-clean and bed/chamber heat-up are open-ended waits (chamber heating can
-    # take up to an hour). Keep the lights on with NO timeout across them:
-    # PRINT_START holds the g-code mutex throughout, so a lights_off that fired
-    # here couldn't run until startup finishes anyway, and any finite value would
-    # just risk turning the lights off the instant the print begins. The bounded
-    # steps on either side keep their own timeouts.
-    LIGHTS
-
     ########################
     # Pre-Clean The Nozzle #
     ########################
     {% if use_touch %}
+      # CLEAN_NOZZLE is fiddly and edited often, so keep the pre-clean guarded by
+      # a timeout: if a bad edit makes it error out before the print starts, the
+      # lights still turn off rather than staying on indefinitely.
+      LIGHTS_OFF_AFTER SECONDS=600
       _NOTIFY T="Pre-Cleaning Nozzle"
       {% set pre_clean_temp = extruder_temp - 60 if extruder_temp - 60 > probe_temp else probe_temp %}
       M104 S{pre_clean_temp}
@@ -71,6 +67,13 @@ gcode:
       CLEAN_NOZZLE TEMP={probe_temp} PURGE=false # Do a second clean at the probe temp to ensure the nozzle is clean for probing
       M106 S0 # Turn off the part cooling fan after cleaning
     {% endif %}
+
+    # Bed and chamber heat-up are open-ended waits (chamber heating can take up to
+    # an hour). Keep the lights on with NO timeout across them: PRINT_START holds
+    # the g-code mutex throughout, so a lights_off that fired here couldn't run
+    # until startup finishes anyway, and any finite value would just risk turning
+    # the lights off the instant the print begins.
+    LIGHTS
 
     #######################
     #  Wait for Heating   #


### PR DESCRIPTION
## Problem

The chamber lights turn off the moment `PRINT_START` finishes (right at the closing `LIGHTS` call), instead of staying on for the print. No error; the print continues.

## Root cause

`PRINT_START` armed a `lights_off` safety timer (`LIGHTS_OFF_AFTER`) before each long phase, intending the closing `LIGHTS` to cancel it on success. But every `delayed_gcode` runs under the g-code command mutex (`gcode.run_script` does `with self.mutex: ...`), and `PRINT_START` holds that mutex for its **entire** run. So when a phase outlasts its timeout:

1. The timer fires mid-`PRINT_START`; its `SET_LED WHITE=0` blocks on the mutex and is **queued**, not run.
2. The closing `LIGHTS` sets `WHITE=0.1` and runs `UPDATE_DELAYED_GCODE DURATION=0` — which only cancels *future* firings; this one already fired.
3. `PRINT_START` ends, releases the mutex → the queued `SET_LED WHITE=0` runs → chamber goes dark.

The lights primitives are unchanged in Kalico (verified): `DURATION=0` still cancels and PWM `SET_LED SYNC=0` still applies immediately. Recent Kalico dispatch/mutex timing changes just made a long phase outlast its timeout reliably, exposing the latent race.

## Fix

A key consequence of the mutex behavior: **a timeout can only ever fire when `PRINT_START` exits** — i.e. when a step *aborts* (raises). If a heater just hangs, the macro is stuck holding the mutex, so a timeout around heating could never turn the lights off; it protected nothing and only risked firing the instant startup finished.

So instead of sizing each timeout to outlast its phase (fragile — a future edit could re-break it), this scopes timeouts to where they can actually do something — the bounded, abort-on-failure steps — and drops them around the open-ended heating waits:

- **Bed (`M190`) + chamber (`M191`) heating → no timeout.** A single `LIGHTS` carries through both. Chamber heating can take up to an hour; this can never misfire regardless of duration.
- **Bounded steps keep reasonable finite timeouts** (they abort cleanly, so the timeout can turn the lights off if startup never reaches the end):
  - Homing → `300s`
  - Nozzle pre-clean → `600s` (kept under a guard deliberately — `CLEAN_NOZZLE` is edited often, so it's a likely place for a future change to break startup)
  - Calibration + priming (gantry level, Z-offset, mesh, prime) → `900s`
- Closing `LIGHTS` keeps the lights on with no timeout for the print.

Net: the lights stay on through a successful startup (including a long chamber heat), still turn off if homing / pre-clean / a probe step aborts, and there's no finite timer around the unbounded heating waits to re-break later.

## Notes

- `CANCEL_PRINT` → `PRINT_END` already arms its own `LIGHTS_OFF_AFTER 300`, so user/UI cancels turn the lights off independently of these guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)