### PR TITLE
fix: Pause on filament stall by checking print_stats.state

### DIFF
--- a/klipper/sensors/filament.cfg
+++ b/klipper/sensors/filament.cfg
@@ -6,7 +6,7 @@ event_delay: 3.0
 pause_delay: 0.5
 runout_gcode:
     _NOTIFY T="Filament Stuck"
-    {% if printer.idle_timeout.state == "printing" %}
+    {% if printer.print_stats.state == "printing" %}
         PAUSE
     {% endif %}
 #insert_gcode:


### PR DESCRIPTION
## Problem

The `[filament_motion_sensor filament_moving]` runout handler is meant to `PAUSE` the print when filament stops moving (a jam/stall), but it never does — it only posts the "Filament Stuck" notification.

```cfg
runout_gcode:
    _NOTIFY T="Filament Stuck"
    {% if printer.idle_timeout.state == "printing" %}   # never matches
        PAUSE
    {% endif %}
```

`printer.idle_timeout.state` reports its value **capitalised** (`"Idle"` / `"Ready"` / `"Printing"`), so the comparison against lowercase `"printing"` is always false and the `PAUSE` is unreachable.

## Fix

Switch the guard to `printer.print_stats.state`, whose state value is lowercase `"printing"` — so the existing string matches and a stall now actually pauses the print while it's running (and still stays a no-op when not printing).

`print_stats` is provided by `[virtual_sdcard]`, which is present on the machine (it prints via Moonraker).

Found while investigating the chamber-lights timing issue (#10); fixed here separately as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJN6RAcnn6VJmu3GxRh9qp)_